### PR TITLE
Template out the website

### DIFF
--- a/store/templates/about.html
+++ b/store/templates/about.html
@@ -2,6 +2,36 @@
 
 {% block content %}
 
-This is the about page
+<!-- Header-->
+<header class="bg-dark py-5">
+    <div class="container px-4 px-lg-5 my-5">
+        <div class="text-center text-white">
+            <h1 class="display-4 fw-bolder">About us ... </h1>
+            <p class="lead fw-normal text-white-50 mb-0">Welcome to my Dj-Ecom website</p>
+        </div>
+    </div>
+</header>
+
+<div class="container">
+    <div class="row">
+        <div class="col-md-8">
+            <h2 class="mt-2" >Our Story</h2>
+            <p align="justify" class="mt-3" >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at nisl in elit pellentesque ullamcorper. Nunc consequat massa leo, at tempor est feugiat at. Pellentesque in orci in tellus mollis auctor. Phasellus in rhoncus ligula. Donec sollicitudin lacus eget accumsan dignissim. Aliquam pretium pellentesque tempus. Etiam suscipit ullamcorper metus sed suscipit.
+                <br/>
+                <br/>
+                Pellentesque leo nulla, gravida sed libero nec, pulvinar dapibus nulla. Nam vel ornare dui. Sed at est et ipsum faucibus interdum in at purus. Donec quis malesuada orci, eget malesuada lorem. Donec sed nisi eu leo pretium hendrerit accumsan eget nibh. Integer iaculis urna eget tempus vestibulum. Sed nisl erat, maximus vel venenatis in, accumsan in nisl. Mauris eu purus eget sem commodo aliquet et eget diam. Sed interdum quis massa sed pellentesque. Maecenas mattis odio enim, et laoreet nisl luctus vitae. Pellentesque consequat est in turpis volutpat, porta ullamcorper magna euismod. Fusce et purus vitae urna lobortis vehicula.
+                <br/>
+                <br/>
+                Proin a est dapibus, posuere odio et, faucibus velit. Integer tincidunt bibendum turpis, nec faucibus tortor feugiat vitae. Proin mattis molestie quam. Donec efficitur porta nibh pharetra mattis. Phasellus ornare lacinia libero eget tempor. Ut consectetur ac lectus eget pharetra. Cras vehicula est sed metus ornare, at efficitur orci scelerisque. Vivamus at lacinia lectus, nec suscipit turpis. Maecenas pretium pulvinar ultrices. Phasellus odio sapien, hendrerit sed augue ut, fermentum sollicitudin nulla. In pharetra sagittis nulla at faucibus. Fusce interdum, sapien et consectetur dignissim, magna neque molestie enim, quis tempus ipsum ipsum nec massa. Nullam et placerat elit. Cras pharetra nulla et purus ullamcorper sagittis.
+                <br/>
+                <br/>
+                Pellentesque leo nulla, gravida sed libero nec, pulvinar dapibus nulla. Nam vel ornare dui. Sed at est et ipsum faucibus interdum in at purus. Donec quis malesuada orci, eget malesuada lorem. Donec sed nisi eu leo pretium hendrerit accumsan eget nibh. Integer iaculis urna eget tempus vestibulum. Sed nisl erat, maximus vel venenatis in, accumsan in nisl. Mauris eu purus eget sem commodo aliquet et eget diam. Sed interdum quis massa sed pellentesque. Maecenas mattis odio enim, et laoreet nisl luctus vitae. Pellentesque consequat est in turpis volutpat, porta ullamcorper magna euismod. Fusce et purus vitae urna lobortis vehicula.
+                <br/>
+                <br/>
+            </p>
+            </p>
+        </div>
+    </div>
+</div>
 
 {% endblock %}

--- a/store/templates/about.html
+++ b/store/templates/about.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+This is the about page
+
+{% endblock %}

--- a/store/templates/base.html
+++ b/store/templates/base.html
@@ -24,7 +24,7 @@
 
         <!-- Footer-->
         <footer class="py-5 bg-dark">
-            <div class="container"><p class="m-0 text-center text-white">Copyright &copy; Your Website 2024</p></div>
+            <div class="container"><p class="m-0 text-center text-white">Copyright &copy; Shenouda - 2024</p></div>
         </footer>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/store/templates/base.html
+++ b/store/templates/base.html
@@ -1,0 +1,34 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="description" content="" />
+        <meta name="author" content="" />
+        <title>Django Ecom</title>
+        <!-- Favicon-->
+        <link rel="icon" type="image/x-icon" href="{% static 'assets/favicon.ico' %} " />
+        <!-- Bootstrap icons-->
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet" />
+        <!-- Core theme CSS (includes Bootstrap)-->
+        <link href="{% static 'css/styles.css' %} " rel="stylesheet" />
+    </head>
+    <body>
+        {% include 'navbar.html'%}
+
+        <!-- This tells the template engine that this section maybe got override by a child template that uses 'extends' with 'block' tag -->
+        {% block content %}
+        {% endblock %}
+
+        <!-- Footer-->
+        <footer class="py-5 bg-dark">
+            <div class="container"><p class="m-0 text-center text-white">Copyright &copy; Your Website 2024</p></div>
+        </footer>
+        <!-- Bootstrap core JS-->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+        <!-- Core theme JS-->
+        <script src="{% static 'js/scripts.js'%} "></script>
+    </body>
+</html>

--- a/store/templates/home.html
+++ b/store/templates/home.html
@@ -1,129 +1,78 @@
-{% load static %}
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <title>Django Ecom</title>
-        <!-- Favicon-->
-        <link rel="icon" type="image/x-icon" href="{% static 'assets/favicon.ico' %} " />
-        <!-- Bootstrap icons-->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet" />
-        <!-- Core theme CSS (includes Bootstrap)-->
-        <link href="{% static 'css/styles.css' %} " rel="stylesheet" />
-    </head>
-    <body>
-        <!-- Navigation-->
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <div class="container px-4 px-lg-5">
-                <a class="navbar-brand" href="#!">Django Ecommerce</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-lg-4">
-                        <li class="nav-item"><a class="nav-link active" aria-current="page" href="#!">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#!">About</a></li>
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Shop</a>
-                            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                <li><a class="dropdown-item" href="#!">All Products</a></li>
-                                <li><hr class="dropdown-divider" /></li>
-                                <li><a class="dropdown-item" href="#!">Popular Items</a></li>
-                                <li><a class="dropdown-item" href="#!">New Arrivals</a></li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <form class="d-flex">
-                        <button class="btn btn-outline-dark" type="submit">
-                            <i class="bi-cart-fill me-1"></i>
-                            Cart
-                            <span class="badge bg-dark text-white ms-1 rounded-pill">0</span>
-                        </button>
-                    </form>
-                </div>
-            </div>
-        </nav>
-        <!-- Header-->
-        <header class="bg-dark py-5">
-            <div class="container px-4 px-lg-5 my-5">
-                <div class="text-center text-white">
-                    <h1 class="display-4 fw-bolder">Shop in style</h1>
-                    <p class="lead fw-normal text-white-50 mb-0">With this shop hompeage template</p>
-                </div>
-            </div>
-        </header>
-        <!-- Section-->
-        <section class="py-5">
-            <div class="container px-4 px-lg-5 mt-5">
-                <div class="row gx-4 gx-lg-5 row-cols-2 row-cols-md-3 row-cols-xl-4 justify-content-center">
-                    {% for prod in products %}
-                    <!-- Sale items -->
-                        {% if prod.is_sale is True %}
-                        <div class="col mb-5">
-                            <div class="card h-100">
-                                <!-- Product image-->
-                                <img class="card-img-top" src="{{prod.image.url}}" alt="..." />
-                                <!-- Sale badge-->
-                                <div class="badge bg-dark text-white position-absolute" style="top: 0.5rem; right: 0.5rem">Sale</div>
-                                <!-- Product details-->
-                                <div class="card-body p-4">
-                                    <div class="text-center">
-                                        <!-- Product name-->
-                                        <h5 class="fw-bolder">{{prod.name}}</h5>
-                                        <!-- Product price-->
-                                        <span class="text-muted text-decoration-line-through">${{prod.price}}</span>
-                                        $ {{prod.sale_price}}
-                                        <br/>
-                                        {{prod.description}}
-                                        <br/>
-                                        In: {{prod.category.name}}
-                                    </div>
-                                </div>
-                                <!-- Product actions-->
-                                <div class="card-footer p-4 pt-0 border-top-0 bg-transparent">
-                                    <div class="text-center"><a class="btn btn-outline-dark mt-auto" href="#">View options</a></div>
-                                </div>
-                            </div>
-                        </div>
-                        {% endif %}
-                        <!-- End Sale items -->
-                         
-                    <!-- Remaining items that does not have sale -->
-                    <div class="col mb-5">
-                        <div class="card h-100">
-                            <!-- Product image-->
-                            <img class="card-img-top" src="{{prod.image.url}}" alt="..." />
-                            <!-- Product details-->
-                            <div class="card-body p-4">
-                                <div class="text-center">
-                                    <!-- Product name-->
-                                    <h5 class="fw-bolder">{{prod.name}}</h5>
-                                    <!-- Product price-->
-                                    ${{prod.price}}
-                                    <br/>
-                                    {{prod.description}}
-                                    <br/>
-                                    In: {{prod.category.name}}
-                                </div>
-                            </div>
-                            <!-- Product actions-->
-                            <div class="card-footer p-4 pt-0 border-top-0 bg-transparent">
-                                <div class="text-center"><a class="btn btn-outline-dark mt-auto" href="#">View options</a></div>
-                            </div>
+{% extends 'base.html' %}
+{% block content %}
+<!-- Header-->
+<header class="bg-dark py-5">
+    <div class="container px-4 px-lg-5 my-5">
+        <div class="text-center text-white">
+            <h1 class="display-4 fw-bolder">Shop in style</h1>
+            <p class="lead fw-normal text-white-50 mb-0">With this shop hompeage template</p>
+        </div>
+    </div>
+</header>
+
+<!-- Section-->
+<section class="py-5">
+    <div class="container px-4 px-lg-5 mt-5">
+        <div class="row gx-4 gx-lg-5 row-cols-2 row-cols-md-3 row-cols-xl-4 justify-content-center">
+            {% for prod in products %}
+            <!-- Sale items -->
+            {% if prod.is_sale is True %}
+            <div class="col mb-5">
+                <div class="card h-100">
+                    <!-- Product image-->
+                    <img class="card-img-top" src="{{prod.image.url}}" alt="..." />
+                    <!-- Sale badge-->
+                    <div class="badge bg-dark text-white position-absolute" style="top: 0.5rem; right: 0.5rem">Sale
+                    </div>
+                    <!-- Product details-->
+                    <div class="card-body p-4">
+                        <div class="text-center">
+                            <!-- Product name-->
+                            <h5 class="fw-bolder">{{prod.name}}</h5>
+                            <!-- Product price-->
+                            <span class="text-muted text-decoration-line-through">${{prod.price}}</span>
+                            $ {{prod.sale_price}}
+                            <br />
+                            {{prod.description}}
+                            <br />
+                            In: {{prod.category.name}}
                         </div>
                     </div>
-                    {% endfor %}
+                    <!-- Product actions-->
+                    <div class="card-footer p-4 pt-0 border-top-0 bg-transparent">
+                        <div class="text-center"><a class="btn btn-outline-dark mt-auto" href="#">View options</a></div>
+                    </div>
                 </div>
             </div>
-        </section>
-        <!-- Footer-->
-        <footer class="py-5 bg-dark">
-            <div class="container"><p class="m-0 text-center text-white">Copyright &copy; Your Website 2024</p></div>
-        </footer>
-        <!-- Bootstrap core JS-->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-        <!-- Core theme JS-->
-        <script src="{% static 'js/scripts.js'%} "></script>
-    </body>
-</html>
+            {% endif %}
+            <!-- End Sale items -->
+
+            <!-- Remaining items that does not have sale -->
+            <div class="col mb-5">
+                <div class="card h-100">
+                    <!-- Product image-->
+                    <img class="card-img-top" src="{{prod.image.url}}" alt="..." />
+                    <!-- Product details-->
+                    <div class="card-body p-4">
+                        <div class="text-center">
+                            <!-- Product name-->
+                            <h5 class="fw-bolder">{{prod.name}}</h5>
+                            <!-- Product price-->
+                            ${{prod.price}}
+                            <br />
+                            {{prod.description}}
+                            <br />
+                            In: {{prod.category.name}}
+                        </div>
+                    </div>
+                    <!-- Product actions-->
+                    <div class="card-footer p-4 pt-0 border-top-0 bg-transparent">
+                        <div class="text-center"><a class="btn btn-outline-dark mt-auto" href="#">View options</a></div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/store/templates/navbar.html
+++ b/store/templates/navbar.html
@@ -8,7 +8,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-lg-4">
                 <li class="nav-item"><a class="nav-link active" aria-current="page" href="#!">Home</a></li>
-                <li class="nav-item"><a class="nav-link" href="#!">About</a></li>
+                <li class="nav-item"><a class="nav-link" href="{% url 'store:about' %}">About</a></li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button"
                         data-bs-toggle="dropdown" aria-expanded="false">Shop</a>

--- a/store/templates/navbar.html
+++ b/store/templates/navbar.html
@@ -1,13 +1,13 @@
 <!-- Navigation-->
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container px-4 px-lg-5">
-        <a class="navbar-brand" href="#!">Django Ecommerce</a>
+        <a class="navbar-brand" href="{% url 'store:home' %}">Django Ecommerce</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span
                 class="navbar-toggler-icon"></span></button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-lg-4">
-                <li class="nav-item"><a class="nav-link active" aria-current="page" href="#!">Home</a></li>
+                <li class="nav-item"><a class="nav-link active" aria-current="page" href="{% url 'store:home' %}">Home</a></li>
                 <li class="nav-item"><a class="nav-link" href="{% url 'store:about' %}">About</a></li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button"

--- a/store/templates/navbar.html
+++ b/store/templates/navbar.html
@@ -1,0 +1,34 @@
+<!-- Navigation-->
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container px-4 px-lg-5">
+        <a class="navbar-brand" href="#!">Django Ecommerce</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span
+                class="navbar-toggler-icon"></span></button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-lg-4">
+                <li class="nav-item"><a class="nav-link active" aria-current="page" href="#!">Home</a></li>
+                <li class="nav-item"><a class="nav-link" href="#!">About</a></li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button"
+                        data-bs-toggle="dropdown" aria-expanded="false">Shop</a>
+                    <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                        <li><a class="dropdown-item" href="#!">All Products</a></li>
+                        <li>
+                            <hr class="dropdown-divider" />
+                        </li>
+                        <li><a class="dropdown-item" href="#!">Popular Items</a></li>
+                        <li><a class="dropdown-item" href="#!">New Arrivals</a></li>
+                    </ul>
+                </li>
+            </ul>
+            <form class="d-flex">
+                <button class="btn btn-outline-dark" type="submit">
+                    <i class="bi-cart-fill me-1"></i>
+                    Cart
+                    <span class="badge bg-dark text-white ms-1 rounded-pill">0</span>
+                </button>
+            </form>
+        </div>
+    </div>
+</nav>

--- a/store/urls.py
+++ b/store/urls.py
@@ -4,5 +4,6 @@ from store import views
 app_name = 'store'
 
 urlpatterns = [
-    path('', views.Home, name="home")
+    path('', views.Home, name="home"),
+    path('about/', views.About, name="about"),
 ]

--- a/store/views.py
+++ b/store/views.py
@@ -6,3 +6,7 @@ from .models import Product
 def Home(request):
     products = Product.objects.all()
     return render(request, 'home.html', {"products":products})
+
+
+def About(request):
+    return render(request, 'about.html')


### PR DESCRIPTION
# Split the website HTML into template blocks

This change extract out common HTML page tags into base.html page as well as the navebar.html. Then any other HTML page will be added as a block. This is being facilitated by the Django templating engine and inheritance feature.

To do so
- Extract common part like HTML head/footer into a `base.html`. Then where we need plug other page content (child page) we will add the
```html
{% block content %}
{% endblock %}
```
This tells the DJango template engine that, the block named `content` may be overridden by another child block that has same name `content`.

Whenever a new html page is developed, will need to do two simple things
1. Add the `{% extends 'base.html' %}`
2. Wrap that page within `{% block content %} Your HTML page here {% endblock %}`

## Issues faced
Another thing I faced during the implementation is an exception that has been raised when I tried to add link for the `about` page within the navbar. The issue was because I wasn't using the full name that should contains the app_name that I defined in the `store/urls.py`.

## References
* [Django Template](https://docs.djangoproject.com/en/5.1/ref/templates/language/)
* [Automatic HTML escaping](https://docs.djangoproject.com/en/5.1/ref/templates/language/#automatic-html-escaping)

